### PR TITLE
feat: add uv + aider-chat (local-LLM code agent)

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -7,5 +7,8 @@
 # mise — activates version-managed tools (Go, Node, Python…) for GUI apps
 eval "$(/opt/homebrew/bin/mise activate zsh)"
 
+# uv tools — Python CLIs installed via `uv tool install` (aider, …)
+export PATH="$HOME/.local/bin:$PATH"
+
 # OrbStack (added by OrbStack installer — keep for container/VM tooling)
 source ~/.orbstack/shell/init.zsh 2>/dev/null || :

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,15 @@ else
   echo "mise not found — run manually: mise install"
 fi
 
+# ── uv tools (Python CLIs) ────────────────────────────────────────────────────
+# Pinned to Python 3.12: aider's pydub dep imports the audioop module, removed in 3.13.
+
+if command -v uv &>/dev/null; then
+  uv tool install --python 3.12 aider-chat   # local-LLM pair-programming / code agent
+else
+  echo "uv not found — skipping uv tools (brew install uv)"
+fi
+
 echo ""
 echo "Done. Open a new shell."
 echo "zinit plugins will auto-clone on first shell open (~5s, needs internet)."

--- a/mac/Brewfile
+++ b/mac/Brewfile
@@ -88,6 +88,8 @@ brew "node"                        # brew dep only — PATH controlled by mise
 brew "python@3.13"                 # brew dep only — PATH controlled by mise
 brew "go"                          # brew dep only — PATH controlled by mise
 
+brew "uv"                          # Python package & tool manager — installs Python CLIs (aider, see install.sh)
+
 # ── Terminal Multiplexer ──────────────────────────────────────────────────────
 
 brew "zellij"                      # terminal workspace / multiplexer (config in .config/zellij/)


### PR DESCRIPTION
Adds the Python tooling for the local-LLM code-offload workflow.

- **Brewfile**: `uv` (Python package & tool manager) — was missing
- **install.sh**: `uv tool install --python 3.12 aider-chat` — pinned to 3.12 because aider's `pydub` dep imports `audioop`, removed in Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)